### PR TITLE
prefetch, cache-refresh 에 대한 예시 작성 과 고민...이 있습니다.

### DIFF
--- a/src/Routes.jsx
+++ b/src/Routes.jsx
@@ -6,6 +6,7 @@ import Profile from '@pages/Profile';
 import Todo from '@pages/Todo';
 import GithubStar from '@pages/GithubStar';
 import SelectorPrefetch from '@pages/SelectorPrefetch';
+import SelectorFamilyPrefetch from '@pages/SelectorFamilyPrefetch';
 
 const Routes = () => {
   return (
@@ -19,6 +20,9 @@ const Routes = () => {
         </Route>
         <Route path="/githubStar">
           <GithubStar />
+        </Route>
+        <Route path="/prefetch-trigger" >
+          <SelectorFamilyPrefetch />
         </Route>
         <Route path="/selector-prefetch">
           <SelectorPrefetch />

--- a/src/Routes.jsx
+++ b/src/Routes.jsx
@@ -5,6 +5,7 @@ import Home from '@pages/Home';
 import Profile from '@pages/Profile';
 import Todo from '@pages/Todo';
 import GithubStar from '@pages/GithubStar';
+import SelectorPrefetch from '@pages/SelectorPrefetch';
 
 const Routes = () => {
   return (
@@ -18,6 +19,9 @@ const Routes = () => {
         </Route>
         <Route path="/githubStar">
           <GithubStar />
+        </Route>
+        <Route path="/selector-prefetch">
+          <SelectorPrefetch />
         </Route>
         <Route path="/">
           <Home />

--- a/src/apis/person.js
+++ b/src/apis/person.js
@@ -1,0 +1,8 @@
+function getPerson(name) {
+  return new Promise((resolve) => {
+    const person = { name, age: name.length * 10 };
+    setTimeout(() => resolve(person), 2000);
+  });
+}
+
+export default getPerson;

--- a/src/apis/person.js
+++ b/src/apis/person.js
@@ -1,7 +1,7 @@
 function getPerson(name) {
   return new Promise((resolve) => {
     const person = { name, age: name.length * 10 };
-    setTimeout(() => resolve(person), 2000);
+    setTimeout(() => resolve(person), 500);
   });
 }
 

--- a/src/components/PersonCard/index.jsx
+++ b/src/components/PersonCard/index.jsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { useRecoilValue } from 'recoil';
+import PropTypes from 'prop-types';
+import { Card } from 'antd';
+import selectorFamilyPrefetch from '@recoil/selectorFamilyPrefetch';
+
+function PersonCard({ name }) {
+  const person = useRecoilValue(selectorFamilyPrefetch.selectorFamilies.personState(name));
+
+  return (
+    <Card title='사람 정보' key={person.name} style={{ width: 300 }}>
+      <p>이름: {person.name}</p>
+      <p>나이: {person.age}</p>
+    </Card>
+  );
+}
+
+PersonCard.propTypes = {
+  name: PropTypes.string,
+};
+
+export default PersonCard;

--- a/src/hooks/useRecoilTrigger.js
+++ b/src/hooks/useRecoilTrigger.js
@@ -1,0 +1,8 @@
+import { useSetRecoilState } from 'recoil';
+
+function useRecoilTrigger(state) {
+  const setTrigger = useSetRecoilState(state);
+  return () => setTrigger(requestID => requestID + 1);
+}
+
+export default useRecoilTrigger;

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -18,6 +18,7 @@ const Home = () => {
           <li><Link to="/todo">TodoList using recoil</Link></li>
           <li><Link to="/githubStar">get githubStar using recoil</Link></li>
           <li><Link to="/selector-prefetch">get selector prefetch using recoil</Link></li>
+          <li><Link to="/prefetch-trigger">get selectorFamily prefetch and refetch using recoil</Link></li>
         </ul>
       </div>
     </>

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -17,6 +17,7 @@ const Home = () => {
           <li><Link to="/profile">Github profile</Link></li>
           <li><Link to="/todo">TodoList using recoil</Link></li>
           <li><Link to="/githubStar">get githubStar using recoil</Link></li>
+          <li><Link to="/selector-prefetch">get selector prefetch using recoil</Link></li>
         </ul>
       </div>
     </>

--- a/src/pages/SelectorFamilyPrefetch.jsx
+++ b/src/pages/SelectorFamilyPrefetch.jsx
@@ -1,0 +1,96 @@
+import React, { useState, Suspense } from 'react';
+import PropTypes from 'prop-types';
+import { useRecoilCallback, useRecoilValueLoadable } from 'recoil';
+import { Button, Input, PageHeader, Space, Timeline } from 'antd';
+
+import PersonCard from '@components/PersonCard';
+import selectorFamilyPrefetch from '@recoil/selectorFamilyPrefetch';
+
+const MSG = {
+  EMPTY_NAME: '추가할 이름을 입력해 주세요.',
+  DUPLICATE_NAME: '동명이인 존재',
+};
+
+function SelectorFamilyPrefetch() {
+  const [ name, setName ] = useState('');
+  const [ personList, setPersonList ] = useState([]);
+  const [ activePersonName, setActivePersonName ] = useState('');
+
+  const onClickAddPerson = () => {
+    if (name === '') {
+      alert(MSG.EMPTY_NAME);
+      return;
+    }
+    const isDuplicateName = personList.some(n => n === name);
+
+    if (isDuplicateName) {
+      alert(MSG.DUPLICATE_NAME);
+      return;
+    }
+
+    setPersonList(prevState => [...prevState, name]);
+    setName('');
+  };
+
+
+  return (
+    <PageHeader
+      title='selectorFamily 에 대한 prefetch 및 캐싱 강제 초기화(refresh) 예제'>
+      <p>테스트 가이드</p>
+      <Timeline>
+        <Timeline.Item>1. 사람 정보를 2개 만들어 줍니다. </Timeline.Item>
+        <Timeline.Item>2. 두번째 사람 정보 불러오기 버튼을 클릭해 2번째 사람의 정보를 확인해 봅니다.</Timeline.Item>
+        <Timeline.Item>3. 첫번쨰 사람 정보 리셋 버튼을 클릭해 첫번째 사람의 정보를 캐싱 초기화해 다시 prefetch 하도록 합니다.</Timeline.Item>
+        <Timeline.Item>4. .5초 기다린 후 첫번째사람 정보 불러오기 버튼을 클릭해서 새로 갱신된 정보가 보이는 것을 확인합니다.</Timeline.Item>
+      </Timeline>
+      <Space>
+        <Input value={name} placeholder='이름을 입력해주세요.' size='medium' onChange={e => setName(e.target.value)} />
+        <Button onClick={onClickAddPerson}>사람 추가</Button>
+        <div>
+          {
+            personList.map((name) => {
+              return <Button key={name} onClick={() => setActivePersonName(name)}>{name} 정보 불러오기</Button>;
+            })
+          }
+        </div>
+        <div>
+          {
+            personList.map(name => <ResetPerson key={name} name={name} />)
+          }
+        </div>
+        <br />
+        {
+          activePersonName !== '' && (
+            <div>
+              <h2>선택한 사람정보</h2>
+              <Suspense fallback={<div>로딩중</div>}>
+                <PersonCard name={activePersonName} />
+              </Suspense>
+            </div>
+          )
+        }
+      </Space>
+    </PageHeader>
+  );
+}
+
+export default SelectorFamilyPrefetch;
+
+function ResetPerson({ name }) {
+  // prefetch 를 위해선 참조하고 있어야 하므로 사용하지 않지만 넣어둔.. 비운의..
+  const preValue = useRecoilValueLoadable(selectorFamilyPrefetch.selectorFamilies.personState(name));
+  const refresh = selectorFamilyPrefetch.trigger.useRefreshUserInfo(name);
+
+  // 실패한 prefetch
+  const onPrefetch = useRecoilCallback(({ snapshot, set }) => async (name) => {
+    await refresh();
+    snapshot.getLoadable(selectorFamilyPrefetch.selectorFamilies.personState(name));
+  });
+
+
+  return <Button key={name} onClick={() => refresh()}>{name} 정보 리셋하기</Button>;
+}
+
+ResetPerson.propTypes = {
+  name: PropTypes.string,
+};

--- a/src/pages/SelectorPrefetch.jsx
+++ b/src/pages/SelectorPrefetch.jsx
@@ -12,6 +12,8 @@ function SelectorPrefetch() {
     snapshot.getLoadable(selectorPrefetch.selectors.personListState);
   });
 
+  const onRefresh = selectorPrefetch.trigger.useRefreshPersonList();
+
   return (
     <PageHeader
       title="selector prefetch 예시"
@@ -19,6 +21,8 @@ function SelectorPrefetch() {
     >
       <Button onClick={() => onPrefetchSelector()}>셀렉터 prefetch 하기</Button>
       <Button onClick={() => setIsShowSelector(true)}>셀렉터 보여주기</Button>
+      <Button onClick={() => onRefresh()}>셀렉터 캐시 새로고침</Button>
+
       {
         isShowSelector && (
           <Suspense fallback={<div>로딩중</div>} >

--- a/src/pages/SelectorPrefetch.jsx
+++ b/src/pages/SelectorPrefetch.jsx
@@ -1,0 +1,52 @@
+import React, { useState, Suspense } from 'react';
+import { useRecoilCallback, useRecoilValue } from 'recoil';
+import { PageHeader, Button, Card } from 'antd';
+
+import selectorPrefetch from '@recoil/selectorPrefetch';
+
+function SelectorPrefetch() {
+  const [ isShowSelector, setIsShowSelector ] = useState(false);
+
+
+  const onPrefetchSelector = useRecoilCallback(({ snapshot }) => async () => {
+    snapshot.getLoadable(selectorPrefetch.selectors.personListState);
+  });
+
+  return (
+    <PageHeader
+      title="selector prefetch 예시"
+      subTitle="'셀렉터 prefetch 하기' 버튼을 먼저 클릭하면 selector에 대한 prefetch 를 먼저 진행하게 되어 '셀렉터 보여주기' 클릭시 이미 요청 완료된 결과를 바로 확인할 수 있습니다. "
+    >
+      <Button onClick={() => onPrefetchSelector()}>셀렉터 prefetch 하기</Button>
+      <Button onClick={() => setIsShowSelector(true)}>셀렉터 보여주기</Button>
+      {
+        isShowSelector && (
+          <Suspense fallback={<div>로딩중</div>} >
+            <SelectorList />
+          </Suspense>
+        )
+      }
+    </PageHeader>
+  );
+}
+
+export default SelectorPrefetch;
+
+function SelectorList() {
+  const personList = useRecoilValue(selectorPrefetch.selectors.personListState);
+
+  return (
+    <>
+      {
+        personList.map((person) => {
+          return (
+            <Card title='사람 정보' key={person.name} style={{ width: 300 }}>
+              <p>이름: {person.name}</p>
+              <p>나이: {person.age}</p>
+            </Card>
+          );
+        })
+      }
+    </>
+  );
+}

--- a/src/recoil/selectorFamilyPrefetch/index.js
+++ b/src/recoil/selectorFamilyPrefetch/index.js
@@ -1,5 +1,6 @@
 
-import { atomFamily, selectorFamily, useSetRecoilState } from 'recoil';
+import { atomFamily, selectorFamily } from 'recoil';
+import useRecoilTrigger from '@hooks/useRecoilTrigger';
 import getPerson from '../../apis/person';
 
 const PREFIX = 'SELECTOR_FAMILY_PREFETCH';
@@ -27,11 +28,7 @@ const selectorFamilies = {
 // 캐싱된 selectFamily 캐시 새로고침용
 const trigger = {
   useRefreshUserInfo(name) {
-    const setTrigger = useSetRecoilState(atomFamilies.personNameState(name));
-    return () => {
-      console.log('call trigger ' + name);
-      setTrigger(requestID => requestID + 1);
-    };
+    return useRecoilTrigger(atomFamilies.personNameState(name));
   },
 };
 

--- a/src/recoil/selectorFamilyPrefetch/index.js
+++ b/src/recoil/selectorFamilyPrefetch/index.js
@@ -1,0 +1,42 @@
+
+import { atomFamily, selectorFamily, useSetRecoilState } from 'recoil';
+import getPerson from '../../apis/person';
+
+const PREFIX = 'SELECTOR_FAMILY_PREFETCH';
+
+
+const atomFamilies = {
+  personNameState: atomFamily({
+    key: `${PREFIX}/personNameState`,
+    default: 0,
+  }),
+};
+
+const selectorFamilies = {
+  personState: selectorFamily({
+    key: `${PREFIX}personState`,
+    get: name => async ({ get }) => {
+      console.log('call : selectorFamilies');
+      // 의존하는 atomFamily가 trigger를 통해 변경되면 새로고침 진행 (캐시 초기화)
+      get(atomFamilies.personNameState(name));
+      return await getPerson(name);
+    },
+  }),
+};
+
+// 캐싱된 selectFamily 캐시 새로고침용
+const trigger = {
+  useRefreshUserInfo(name) {
+    const setTrigger = useSetRecoilState(atomFamilies.personNameState(name));
+    return () => {
+      console.log('call trigger ' + name);
+      setTrigger(requestID => requestID + 1);
+    };
+  },
+};
+
+export default {
+  atomFamilies,
+  selectorFamilies,
+  trigger,
+};

--- a/src/recoil/selectorPrefetch/index.js
+++ b/src/recoil/selectorPrefetch/index.js
@@ -1,5 +1,6 @@
 
 import { selector } from 'recoil';
+import getPerson from '../../apis/person';
 
 const PREFIX = 'SELECTOR_PREFETCH';
 
@@ -16,13 +17,4 @@ const selectors = {
 export default {
   selectors,
 };
-
-const getPerson = name => new Promise((resolve) => {
-  const person = {
-    name,
-    age: name.length * 10,
-  };
-
-  setTimeout(() => resolve(person), 2000);
-});
 

--- a/src/recoil/selectorPrefetch/index.js
+++ b/src/recoil/selectorPrefetch/index.js
@@ -1,20 +1,40 @@
 
-import { selector } from 'recoil';
+import { atom, selector, useSetRecoilState} from 'recoil';
 import getPerson from '../../apis/person';
 
 const PREFIX = 'SELECTOR_PREFETCH';
 
+const atoms = {
+  personListTriggerState: atom({
+    key: `${PREFIX}/personListTriggerState`,
+    default: 0,
+  }),
+};
+
 const selectors = {
   personListState: selector({
     key: `${PREFIX}/personListState`,
-    get: async () => {
+    get: async ({ get }) => {
+      get(atoms.personListTriggerState); // 캐싱 트리거용
       const [ person1, person2 ] = await Promise.all([getPerson('1'), getPerson('2')]);
       return [person1, person2];
     },
   }),
 };
 
+// 캐싱된 select 캐시 새로고침용
+const trigger = {
+  useRefreshPersonList() {
+    const setTrigger = useSetRecoilState(atoms.personListTriggerState);
+    return () => {
+      console.log('call trigger useRefreshPersonList');
+      setTrigger(requestID => requestID + 1);
+    };
+  },
+};
+
 export default {
   selectors,
+  trigger,
 };
 

--- a/src/recoil/selectorPrefetch/index.js
+++ b/src/recoil/selectorPrefetch/index.js
@@ -1,0 +1,28 @@
+
+import { selector } from 'recoil';
+
+const PREFIX = 'SELECTOR_PREFETCH';
+
+const selectors = {
+  personListState: selector({
+    key: `${PREFIX}/personListState`,
+    get: async () => {
+      const [ person1, person2 ] = await Promise.all([getPerson('1'), getPerson('2')]);
+      return [person1, person2];
+    },
+  }),
+};
+
+export default {
+  selectors,
+};
+
+const getPerson = name => new Promise((resolve) => {
+  const person = {
+    name,
+    age: name.length * 10,
+  };
+
+  setTimeout(() => resolve(person), 2000);
+});
+

--- a/src/recoil/selectorPrefetch/index.js
+++ b/src/recoil/selectorPrefetch/index.js
@@ -1,5 +1,6 @@
 
-import { atom, selector, useSetRecoilState} from 'recoil';
+import { atom, selector } from 'recoil';
+import useRecoilTrigger from '@hooks/useRecoilTrigger';
 import getPerson from '../../apis/person';
 
 const PREFIX = 'SELECTOR_PREFETCH';
@@ -25,11 +26,7 @@ const selectors = {
 // 캐싱된 select 캐시 새로고침용
 const trigger = {
   useRefreshPersonList() {
-    const setTrigger = useSetRecoilState(atoms.personListTriggerState);
-    return () => {
-      console.log('call trigger useRefreshPersonList');
-      setTrigger(requestID => requestID + 1);
-    };
+    return useRecoilTrigger(atoms.personListTriggerState);
   },
 };
 


### PR DESCRIPTION
1. selector 에 대한 prefetch, 및 캐시 refresh에 대한 예시를 작성하였습니다. (selector-prefetch 라우트 참조)
2. selectorFamily에 대한 prefetch 및 캐시 refresh에 대한 예시를 작성하였습니다. (prefetch-trigger 라우트 참조)
3. cache trigger에 대한 중복을 제거한 hooks 함수인 `useRecoilTrigger 를 만들었습니다.

## 고민.. selectorFamily 에 대한 prefetch

1. selectorFamily에 대해 prefetch 를 진행하기 위해 처음에는 작성한 trigger를 호출한 후 `useRecoilCallback` 의 getLoadble 을 사용해 prefetch 를 진행하려 했으나 `useRecoilCallback` 에서 참조하는 시점이 trigger를 통해 의존성 atomFamily가 바뀌기 전이라 실패하였습니다.
`resetPerson` 컴포넌트에 실패한 함수가 존재합니다. 

2. 시점문제로 인해 `useRecoilCallback` 안에서 set을 통해 atomTrigger를 변경후 `getLoadble` 을 통해 참조하는 방향으로 했지만 해당 콜백 시점에서는 set으로 바뀌어도 `getLoadble`  에서 참조하는 값은 변경전의 atomFamily 값을 보기때문에 이역시 실패했습니다..

### 관련 예시 코드

```js
 const changeUser = useRecoilCallback(({snapshot, set}) => async (userID: number) => {
        // 여기서 atomFamily를 변경하려 해도 이전 값에 + 1 을 해야 하는데 이를 또 참고하기 위해 선언해야하는 불편함 존재.
       set(userInfoQueryRequestIDState(userID), 999); 
       // 해당 snapshot 시점에서는 위에서 변경하여도 현재 시점인 변경 전 시점으로 보기때문에 역시 되지 않음.
        snapshot.getLoadable(userInfoQuery(userID)); 
    });
```

3. 때문에 현재 trigger를 통해 새로고침하는 부분에 해당 selectFamily를 가져와서 refresh 를 통해 의존중인 atomFamily가 변경시 prefetch 가 되도록 꼼수적인 방법으로 해결은 하였으나 사용하지 않고 선언해둔 코드가 되서 이부분이 마음에 걸립니다.ㅠ

selectFamily 에 대한 prefetch 방법을 좀더 고민하면 좋을거 같아요.~ :)
혹시 더 좋은 방법이 있으시면 같이 논의하면 좋을것 같습니다.~!! 